### PR TITLE
Added secure support

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -21,6 +21,7 @@ You can configure the directive using the following attributes:
 * Size - You can specify the size of the avatar image using the data-size attribute. The default is 40 pixels.
 * Rating - You can specify a rating to limit what avatars are displayed. The default rating is PG.
 * Default Image - You can specify a default image to display if the email address does not have an associated avatar. The default is 404.
+* Secure - You can optionally specify a true value in the data-secure attribute to request the SSL version of the avatar.
 
 For more information about the Gravatar Image request check out their [Developer's Reference](http://en.gravatar.com/site/implement/).
 

--- a/app/index.html
+++ b/app/index.html
@@ -25,7 +25,7 @@
     <div class="row-fluid">
         <h2>Gravatar Directive Example</h2>
 
-        <gravatar-image data-email="email" data-size="120" data-rating="pg" data-default="404" ></gravatar-image>
+        <gravatar-image data-email="email" data-size="120" data-rating="pg" data-default="404" data-secure="true"></gravatar-image>
 
     </div>
 </div>

--- a/src/gravatar-directive.js
+++ b/src/gravatar-directive.js
@@ -38,7 +38,7 @@ angular.module('ui-gravatar', ['md5']).
                             defaultUrl = '404';
                         }
                         // construct the tag to insert into the element
-                        var tag = '<img src="http://www.gravatar.com/avatar/' + hash + '?s=' + size + '&r=' + rating + '&d=' + defaultUrl + '" >'
+                        var tag = '<img src="' + (attrs.secure ? 'https://secure' : 'http://www' ) + '.gravatar.com/avatar/' + hash + '?s=' + size + '&r=' + rating + '&d=' + defaultUrl + '" >'
                         // insert the tag into the element
                         elm.append(tag);
                     }


### PR DESCRIPTION
I've added support for SSL gravatar urls (see bottom of http://en.gravatar.com/site/implement/images/) when the data-secure attribute is true.
