### PR TITLE
Remove existing images before adding a new one.

### DIFF
--- a/src/gravatar-directive.js
+++ b/src/gravatar-directive.js
@@ -38,7 +38,9 @@ angular.module('ui-gravatar', ['md5']).
                             defaultUrl = '404';
                         }
                         // construct the tag to insert into the element
-                        var tag = '<img src="' + (attrs.secure ? 'https://secure' : 'http://www' ) + '.gravatar.com/avatar/' + hash + '?s=' + size + '&r=' + rating + '&d=' + defaultUrl + '" >'
+                        var tag = '<img class="gravatar-icon" src="' + (attrs.secure ? 'https://secure' : 'http://www' ) + '.gravatar.com/avatar/' + hash + '?s=' + size + '&r=' + rating + '&d=' + defaultUrl + '" >'
+                        //remove any existing imgs 
+                        $(".gravatar-icon").remove();            
                         // insert the tag into the element
                         elm.append(tag);
                     }


### PR DESCRIPTION
Currently if I am changing my email address the directive adds new images every few seconds. This either adds the default image while my email address is invalid or the gravatar matching the email address. 

There is probably a prettier way to do it.

Cheers 
Jono
