### PR TITLE
Allow additional css classes to be applied using the data-css-class attribute.

### DIFF
--- a/src/gravatar-directive.js
+++ b/src/gravatar-directive.js
@@ -37,10 +37,19 @@ angular.module('ui-gravatar', ['md5']).
                         if((defaultUrl === null) || (defaultUrl === undefined)|| (defaultUrl === '')) {
                             defaultUrl = '404';
                         }
+                        // parse any additional css classes
+                        var cssClass = attrs.cssClass;
+                        if((cssClass === null) || (cssClass === undefined)|| (cssClass === '')) {
+                          cssClass = 'gravatar-icon';
+                        }
+                        else {
+                          cssClass = cssClass + ' gravatar-icon';
+                        }
+
                         // construct the tag to insert into the element
-                        var tag = '<img class="gravatar-icon" src="' + (attrs.secure ? 'https://secure' : 'http://www' ) + '.gravatar.com/avatar/' + hash + '?s=' + size + '&r=' + rating + '&d=' + defaultUrl + '" >'
-                        //remove any existing imgs 
-                         $(elm).find(".gravatar-icon").remove();           
+                        var tag = '<img class="' + cssClass + '" src="' + (attrs.secure ? 'https://secure' : 'http://www' ) + '.gravatar.com/avatar/' + hash + '?s=' + size + '&r=' + rating + '&d=' + defaultUrl + '" >'
+                        //remove any existing imgs
+                         $(elm).find(".gravatar-icon").remove();
                         // insert the tag into the element
                         elm.append(tag);
                     }


### PR DESCRIPTION
This allows popular Bootstrap CSS like img-rounded or img-circle to be applied to the gravatar.

BTW, I really like the usefulness of your directive and plan on using it in my projects.  It was pretty much a drop-in to AngularJS.
