### PR TITLE
Made getImageSrc arguments optional

### DIFF
--- a/src/gravatar-directive.js
+++ b/src/gravatar-directive.js
@@ -14,7 +14,10 @@ angular.module('ui-gravatar', ['md5']).
             getImageSrc : function(value, size, rating, defaultUrl, secure) {
                 // convert the value to lower case and then to a md5 hash
                 var hash = md5.createHash(value.toLowerCase());
-                var src = (secure ? 'https://secure' : 'http://www' ) + '.gravatar.com/avatar/' + hash + '?s=' + size + '&r=' + rating + '&d=' + defaultUrl;
+                var src = (secure ? 'https://secure' : 'http://www' ) + '.gravatar.com/avatar/' + hash;
+                if (size) src += '?s=' + size;
+                if (rating) src += '&r=' + rating;
+                if (defaultUrl) src += '&d=' + defaultUrl;
                 return src;
             }
         };


### PR DESCRIPTION
This is probably the simplest solution that doesn't break existing code.  I didn't touch the tests ans I couldn't get them to work on my version of Karma.

I think perhaps in the long run it would be better to do something like this (not tested):

``` js
            function(value, options) {
                var options = options || {};
                angular.extend(options, defaults);

                var hash = md5.createHash(value.toLowerCase());
                var src = (options.secure ? 'https://secure' : 'http://www' ) + '.gravatar.com/avatar/' + hash;
                if (options.size) src += '?s=' + options.size;
                if (options.rating) src += '&r=' + options.rating;
                if (options.default) src += '&d=' + options.default;
                return src;
            }
```

Where defaults could be set on config.
