### PR TITLE
Adding main call in bower.jsons for grunt bower installs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
     "name": "angularjs-gravatardirective",
     "version": "1.3.2",
+    "main" : "./dist/angularjs-gravatardirective.min.js",
     "dependencies": {
         "angular": "~1.2.12"
     },


### PR DESCRIPTION
bower-install Grunt task won't run without a 'main' definition inside the bower.json path
